### PR TITLE
Añadido jarRepositories.xml al .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/jarRepositories.xml
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
En esta PR se va a añadir el archivo autogenerado jarRepositories.xml al .gitignore para que deje de molestar al trabajar con git.

En esta pregunta de Stack Overflow se explica el porqué:
https://stackoverflow.com/questions/63342780/how-can-i-decide-to-add-idea-jarrepositories-xml-in-gitignore

![Screenshot_2020-10-14 How can I decide to add idea jarRepositories xml in gitignore](https://user-images.githubusercontent.com/29706923/95972520-d6bf6600-0e12-11eb-9ce3-e7c8b3cd13fd.png)
