### PR TITLE
 FIX: Iniciar la creación de un nuevo Punto de Interés cuando ya hay una en proceso

### DIFF
--- a/app/src/main/java/app/paseico/CreateNewRouteActivity.java
+++ b/app/src/main/java/app/paseico/CreateNewRouteActivity.java
@@ -367,14 +367,13 @@ public class CreateNewRouteActivity extends AppCompatActivity implements OnMapRe
         registerOnNewPoiButtonClicked(bottomSheetBehavior);
 
         createNewRouteMap.setOnMapLongClickListener(tapPoint -> {
+            tryDeleteUserNewCustomPoiInCreation();
+
             // Opens the creation form.
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
-            if(isUserCreatingACustomPoi()){
-                userNewCustomPoiInCreation.remove();
-            }
+
             userNewCustomPoiInCreation = createNewRouteMap
                     .addMarker(new MarkerOptions().position(tapPoint).title("User Marker"));
-
         });
     }
 


### PR DESCRIPTION
Esta PR tarta de solucionar el bug descrito en la UT 2251:
[https://cliente.tuneupprocess.com/web/#/wum/2251](url)
